### PR TITLE
localStorage上に保存・読込機能を実装、テストで取得状況に合わせて表示を切り替える機能も実装

### DIFF
--- a/src/assets/json/stamplist.json
+++ b/src/assets/json/stamplist.json
@@ -3,30 +3,16 @@
     "location": "1号館",
     "shop": [
       {
-        "id": 152,
+        "id": "152",
         "name": "ストラックアウト",
         "classname": "CG1X",
         "category": "文化店",
         "imagepath": "nkc-ug.jpg"
       },
       {
-        "id": 143,
+        "id": "162",
         "name": "脱出ゲーム ",
         "classname": "GG1X",
-        "category": "文化店",
-        "imagepath": "nkc-ug.jpg"
-      },
-      {
-        "id": 176,
-        "name": "クイズ大会",
-        "classname": "NKC-UG",
-        "category": "文化店",
-        "imagepath": "nkc-ug.jpg"
-      },
-      {
-        "id": 133,
-        "name": "展示",
-        "classname": "CG1X",
         "category": "文化店",
         "imagepath": "nkc-ug.jpg"
       }
@@ -36,30 +22,16 @@
     "location": "3号館",
     "shop": [
       {
-        "id": 152,
+        "id": "334",
         "name": "ストラックアウト",
         "classname": "CG1X",
         "category": "文化店",
         "imagepath": "nkc-ug.jpg"
       },
       {
-        "id": 143,
-        "name": "脱出ゲーム ",
-        "classname": "GG1X",
-        "category": "文化店",
-        "imagepath": "nkc-ug.jpg"
-      },
-      {
-        "id": 176,
+        "id": "352",
         "name": "クイズ大会",
         "classname": "NKC-UG",
-        "category": "文化店",
-        "imagepath": "nkc-ug.jpg"
-      },
-      {
-        "id": 133,
-        "name": "展示",
-        "classname": "CG1X",
         "category": "文化店",
         "imagepath": "nkc-ug.jpg"
       }
@@ -69,30 +41,16 @@
     "location": "10号館",
     "shop": [
       {
-        "id": 152,
+        "id": "1032",
         "name": "ストラックアウト",
         "classname": "CG1X",
         "category": "文化店",
         "imagepath": "nkc-ug.jpg"
       },
       {
-        "id": 143,
+        "id": "1042",
         "name": "脱出ゲーム ",
         "classname": "GG1X",
-        "category": "文化店",
-        "imagepath": "nkc-ug.jpg"
-      },
-      {
-        "id": 176,
-        "name": "クイズ大会",
-        "classname": "NKC-UG",
-        "category": "文化店",
-        "imagepath": "nkc-ug.jpg"
-      },
-      {
-        "id": 133,
-        "name": "展示",
-        "classname": "CG1X",
         "category": "文化店",
         "imagepath": "nkc-ug.jpg"
       }
@@ -102,30 +60,16 @@
     "location": "チャレンジングロット",
     "shop": [
       {
-        "id": 152,
+        "id": "01",
         "name": "ストラックアウト",
         "classname": "CG1X",
         "category": "文化店",
         "imagepath": "nkc-ug.jpg"
       },
       {
-        "id": 143,
+        "id": "02",
         "name": "脱出ゲーム ",
         "classname": "GG1X",
-        "category": "文化店",
-        "imagepath": "nkc-ug.jpg"
-      },
-      {
-        "id": 176,
-        "name": "クイズ大会",
-        "classname": "NKC-UG",
-        "category": "文化店",
-        "imagepath": "nkc-ug.jpg"
-      },
-      {
-        "id": 133,
-        "name": "展示",
-        "classname": "CG1X",
         "category": "文化店",
         "imagepath": "nkc-ug.jpg"
       }

--- a/src/component/StampData.ts
+++ b/src/component/StampData.ts
@@ -1,0 +1,29 @@
+export const SetStampData = (id: string, isGet: boolean) => {
+  const tmpjson = [
+    { id: "152", isGet: false },
+    { id: "162", isGet: false },
+    { id: "334", isGet: false },
+    { id: "352", isGet: false },
+    { id: "618", isGet: false },
+    { id: "1032", isGet: false },
+    { id: "1042", isGet: false },
+    { id: "01", isGet: false },
+    { id: "02", isGet: false },
+  ];
+  const json = tmpjson.map((stamp) =>
+    stamp.id === id ? { ...stamp, isGet: isGet } : stamp
+  );
+  const data = JSON.stringify(json, null, 2);
+  localStorage.setItem("Meigakusai-Stamprally2024", data);
+};
+type StampData = {
+  id: string;
+  isGet: boolean;
+};
+export const GetStampData = (id: string) => {
+  const json = JSON.parse(
+    String(localStorage.getItem("Meigakusai-Stamprally2024"))
+  );
+  const element = json.find((element: StampData) => element.id === id);
+  return element.isGet ?? false;
+};

--- a/src/component/StampView.tsx
+++ b/src/component/StampView.tsx
@@ -1,6 +1,7 @@
 import { Box, Grid, Typography } from "@mui/material";
 import React from "react";
 import { LocationStamp } from "../types/Stampdatatype";
+import { GetStampData } from "./StampData";
 
 type LocationStampProp = {
   json: LocationStamp;
@@ -13,7 +14,11 @@ export const StampView: React.FC<LocationStampProp> = ({ json }) => {
       <Grid item sx={{ width: "27%", margin: "4px" }} key={index}>
         <img
           src={imagespath + data.imagepath}
-          style={{ width: "100%", height: "auto" }}
+          style={{
+            width: "100%",
+            height: "auto",
+            filter: !GetStampData(data.id) ? "saturate(0%)" : "",
+          }}
           alt={data.name}
         />
         <Typography variant="h6">{data.name}</Typography>

--- a/src/types/Stampdatatype.ts
+++ b/src/types/Stampdatatype.ts
@@ -4,7 +4,7 @@ export type LocationStamp = {
 };
 
 export type ShopData = {
-  id: number;
+  id: string;
   name: string;
   classname: string;
   category: string;


### PR DESCRIPTION
## 実装内容
ローカルストレージ上に対してスタンプの取得状況を保存・取得できるようにした。
SetStampData("店舗ID",bool)で該当店舗のスタンプの取得状態を切り替え可能。
GetStampData("店舗ID")で該当店舗のスタンプの取得状態を取得。

## 変更内容
チャレンジングロットの店舗IDが二桁かつ0から始まるものも含まれるのでstring形に変更