### PR TITLE
デプロイ用の修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "eslint": "^8.57.0",
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-react-refresh": "^0.4.7",
+        "gh-pages": "^6.1.1",
         "typescript": "^5.2.2",
         "vite": "^5.3.4"
       }
@@ -1928,6 +1929,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true
+    },
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
@@ -2062,6 +2078,21 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2209,6 +2240,12 @@
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.4.tgz",
       "integrity": "sha512-orzA81VqLyIGUEA77YkVA1D+N+nNfl2isJVjjmOyrlxuooZ19ynb+dOlaDTqd/idKRS9lDCSBmtzM+kyCsMnkA==",
+      "dev": true
+    },
+    "node_modules/email-addresses": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-5.0.0.tgz",
+      "integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==",
       "dev": true
     },
     "node_modules/error-ex": {
@@ -2640,6 +2677,32 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/filename-reserved-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/filenamify": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
+      "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
+      "dev": true,
+      "dependencies": {
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.1",
+        "trim-repeated": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2650,6 +2713,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
     "node_modules/find-root": {
@@ -2693,6 +2773,20 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
+    "node_modules/fs-extra": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2728,6 +2822,56 @@
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/gh-pages": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-6.1.1.tgz",
+      "integrity": "sha512-upnohfjBwN5hBP9w2dPE7HO5JJTHzSGMV1JrLrHvNuqmjoYHg6TBrCcnEoorjG/e0ejbuvnwyKMdTyM40PEByw==",
+      "dev": true,
+      "dependencies": {
+        "async": "^3.2.4",
+        "commander": "^11.0.0",
+        "email-addresses": "^5.0.0",
+        "filenamify": "^4.3.0",
+        "find-cache-dir": "^3.3.1",
+        "fs-extra": "^11.1.1",
+        "globby": "^6.1.0"
+      },
+      "bin": {
+        "gh-pages": "bin/gh-pages.js",
+        "gh-pages-clean": "bin/gh-pages-clean.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gh-pages/node_modules/array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
+      "dev": true,
+      "dependencies": {
+        "array-uniq": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gh-pages/node_modules/globby": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "integrity": "sha512-KVbFv2TQtbzCoxAnfD6JcHZTYCzyliEaaeM/gH8qQdkKr5s0OP9scEgvdcngyk7AVdY6YVW/TJHd+lQ/Df3Daw==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^1.0.1",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/glob": {
@@ -2812,6 +2956,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -3049,6 +3199,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3115,6 +3277,30 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/mdn-data": {
@@ -3282,6 +3468,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3365,6 +3560,100 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
+      "dev": true,
+      "dependencies": {
+        "pinkie": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/postcss": {
@@ -3873,6 +4162,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-outer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/stylis": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
@@ -3938,6 +4239,18 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
       "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
+    },
+    "node_modules/trim-repeated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/ts-api-utils": {
       "version": "1.3.0",
@@ -4008,6 +4321,15 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "meigakusai-stamprally2024",
+  "homepage": "https:/nkc-ug.github.io/meigakusai-stamprally2024/",
   "private": true,
   "version": "0.0.0",
   "type": "module",
@@ -7,7 +8,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "deploy": "gh-pages -d dist",
+    "postbuild": "copy dist\\index.html dist\\404.html"
   },
   "dependencies": {
     "@emotion/react": "^11.13.0",
@@ -35,6 +38,7 @@
     "eslint": "^8.57.0",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.7",
+    "gh-pages": "^6.1.1",
     "typescript": "^5.2.2",
     "vite": "^5.3.4"
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import { ParticipationGuide } from "./pages/ParticipationGuid";
 
 function App() {
   return (
-    <BrowserRouter>
+    <BrowserRouter basename="/meigakusai-stamprally2024/">
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/participation" element={<ParticipationGuide />} />

--- a/src/assets/json/stamplist.json
+++ b/src/assets/json/stamplist.json
@@ -7,56 +7,56 @@
         "name": "模擬店名",
         "classname": "クラス名",
         "category": "文化店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "135",
         "name": "みんなのGameParty",
         "classname": "ゲーム総合学科4年A組",
         "category": "文化店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "144",
         "name": "お化けやしき(仮)",
         "classname": "ゲーム総合学科2年B組 \n ゲーム総合学科3年B組",
         "category": "文化店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "145",
         "name": "トランプゲーム「ALL In」",
         "classname": "ゲームCG学科2年",
         "category": "文化店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "155",
         "name": "ゲームセンター☆ウメダ",
         "classname": "情報総合学科2年B組",
         "category": "文化店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "163",
         "name": "GG -GO GAME-",
         "classname": "情報総合学科2年A組",
         "category": "文化店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "165",
         "name": "射的訓練場",
         "classname": "情報総合学科1年B組",
         "category": "文化店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "174",
         "name": "帝Loveグループ",
         "classname": "情報総合学科1年A組",
         "category": "文化店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       }
     ]
   },
@@ -68,49 +68,49 @@
         "name": "仏の岩佐",
         "classname": "電業技術学科2年",
         "category": "文化店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "346",
         "name": "モーリーファンタジー",
         "classname": "情報総合学科3年B組",
         "category": "文化店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "347",
         "name": "オアシスCS3",
         "classname": "情報システム科3年 \n IT技術研究科1年",
         "category": "文化店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "351",
         "name": "リアルサンクチュアリ",
         "classname": "ゲーム総合学科4年B組 \n ゲーム研究科1年",
         "category": "文化店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "353",
         "name": "ゲームファンタジー",
         "classname": "情報システム科2年",
         "category": "文化店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "354",
         "name": "やわらかしゅーてぃんぐ",
         "classname": "情報総合学科3年A組",
         "category": "文化店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "357",
         "name": "C1Amuse",
         "classname": "情報処理学科1年A組",
         "category": "文化店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       }
     ]
   },
@@ -122,28 +122,28 @@
         "name": "ちゃんとした休憩所",
         "classname": "機械制御科2年",
         "category": "文化店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "1043",
         "name": "control + break",
         "classname": "電子情報研究科1年",
         "category": "文化店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "1046",
         "name": "ボードゲームFlugel",
         "classname": "機械CAD設計科1年",
         "category": "文化店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "1051",
         "name": "工学院レトロランド",
         "classname": "電子情報学科1年",
         "category": "文化店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       }
     ]
   },
@@ -155,189 +155,189 @@
         "name": "チュロスとフライドおいものマリアージュ",
         "classname": "情報処理学科2年",
         "category": "飲食店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "02",
         "name": "ラーメン鳥居",
         "classname": "情報総合学科4年B組",
         "category": "飲食店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "03",
         "name": "鉄板中島屋",
         "classname": "情報システム科2年",
         "category": "飲食店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "04",
         "name": "団子のよしろう",
         "classname": "事務局",
         "category": "飲食店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "05",
         "name": "スーパーボールすくい",
         "classname": "コンピュータ・IT分野",
         "category": "飲食店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "06",
         "name": "おからあげ",
         "classname": "機械工学科1年",
         "category": "飲食店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "07",
         "name": "ブチ揚げ屋",
         "classname": "電子情報研究科1年",
         "category": "飲食店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "08",
         "name": "アゲアゲぱん",
         "classname": "ゲームサイエンス学科2年 \n ゲーム総合学科2年C組",
         "category": "飲食店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "09",
         "name": "大人のベビーカステラ",
         "classname": "情報システム科3年",
         "category": "飲食店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "10",
         "name": "チュンチュロ",
         "classname": "IoT技術学科2年",
         "category": "飲食店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "11",
         "name": "未定",
         "classname": "ゲーム総合学科4年A組",
         "category": "飲食店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "12",
         "name": "焼鳥炭ちゃん",
         "classname": "電気工学科1年A組",
         "category": "飲食店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "13",
         "name": "エターナル焼きそば",
         "classname": "ゲーム総合学科1年B組 \n ゲームCG学科1年",
         "category": "飲食店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "14",
         "name": "String meet.\"焼き鳥\"",
         "classname": "情報システム科1年A組",
         "category": "飲食店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "15",
         "name": "コシーニャ屋",
         "classname": "情報システム科1年B組",
         "category": "飲食店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "16",
         "name": "薮木おじさんのチュロス",
         "classname": "情報総合学科1年B組",
         "category": "飲食店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "17",
         "name": "はらぺこ食堂",
         "classname": "情報処理学科1年B組 \n AIイノベーション学科1年",
         "category": "飲食店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "18",
         "name": "はな◯製麺",
         "classname": "電気工学研究科1年",
         "category": "飲食店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "19",
         "name": "爆裂ポップコーン",
         "classname": "機械制御科1年",
         "category": "飲食店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "20",
         "name": "喫茶「青い鳥」",
         "classname": "機械CAD設計科2年",
         "category": "飲食店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "21",
         "name": "あげたこ焼き",
         "classname": "ゲーム総合学科3年A組",
         "category": "飲食店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "22",
         "name": "ヤンのチヂミ",
         "classname": "IoT技術学科1年",
         "category": "飲食店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "23",
         "name": "未定",
         "classname": "AIシステム科2年 \n 情報セキュリティ学科2年",
         "category": "飲食店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "24",
         "name": "IPPONフランク",
         "classname": "電気工学科2年B組",
         "category": "飲食店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "25",
         "name": "やきとりとりとり串タンタン♪",
         "classname": "映像音響科1年",
         "category": "飲食店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "26",
         "name": "未定",
         "classname": "ゲームCG学科2年",
         "category": "飲食店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       },
       {
         "id": "27",
         "name": "串屋　曽我部家",
         "classname": "映像音響科2年",
         "category": "飲食店",
-        "imagepath": "nkc-ug.jpg"
+        "imagepath": "sample"
       }
     ]
   }

--- a/src/component/StampImage.ts
+++ b/src/component/StampImage.ts
@@ -1,0 +1,9 @@
+import sample from "/src/assets/images/stamp/nkc-ug.jpg";
+
+export const StampImage = (stamp: string) => {
+  const STAMPIMAGE_LIST: { [key: string]: string } = {
+    sample: sample,
+  };
+
+  return STAMPIMAGE_LIST[stamp] ?? sample;
+};

--- a/src/component/StampView.tsx
+++ b/src/component/StampView.tsx
@@ -2,13 +2,14 @@ import { Box, Grid, Typography } from "@mui/material";
 import React from "react";
 import { LocationStamp } from "../types/Stampdatatype";
 import { GetStampData } from "./StampData";
+import unacquired from "/src/assets/images/symbol/unacquired.png";
+import { StampImage } from "./StampImage";
 
 type LocationStampProp = {
   json: LocationStamp;
 };
 
 export const StampView: React.FC<LocationStampProp> = ({ json }) => {
-  const imagespath = "src/assets/images/stamp/";
   const shoplist = json.shop.map((data, index) => {
     const gotStamp = GetStampData(data.id);
     return (
@@ -26,7 +27,7 @@ export const StampView: React.FC<LocationStampProp> = ({ json }) => {
               }}
             >
               <img
-                src="src/assets/images/symbol/unacquired.png"
+                src={unacquired}
                 style={{
                   width: "100%",
                   height: "auto",
@@ -36,7 +37,7 @@ export const StampView: React.FC<LocationStampProp> = ({ json }) => {
             </Box>
           )}
           <img
-            src={imagespath + data.imagepath}
+            src={StampImage(data.imagepath)}
             style={{
               width: "100%",
               height: "auto",

--- a/src/pages/StampGet.tsx
+++ b/src/pages/StampGet.tsx
@@ -6,11 +6,11 @@ import { SetStampData } from "../component/StampData";
 import { HashingSha1 } from "../component/HashingSha1";
 import { useEffect, useState } from "react";
 import { useReward } from "react-rewards";
+import { StampImage } from "../component/StampImage";
 
 export const StampGet = () => {
   const nav = useNavigate();
   const id = useParams();
-  const imagesPath = "/src/assets/images/stamp/";
   const [stampData, setStampData] = useState({
     shopname: "",
     classname: "",
@@ -32,7 +32,7 @@ export const StampGet = () => {
       setStampData({
         shopname: shopData ? shopData.name : "",
         classname: shopData ? shopData.classname : "",
-        imagepath: shopData ? `${imagesPath}${shopData.imagepath}` : "",
+        imagepath: shopData ? shopData.imagepath : "",
       });
     }, [shopData]);
     return shopData ? <SuccessProcess /> : <ErrorProcess />;
@@ -51,7 +51,7 @@ export const StampGet = () => {
         >
           <Typography variant="h4">スタンプゲット！</Typography>
           <Box>
-            <img src={stampData.imagepath} alt="stamp" />
+            <img src={StampImage(stampData.imagepath)} alt="stamp" />
             <Typography variant="h5">{stampData.shopname}</Typography>
             <Typography variant="h5">{stampData.classname}</Typography>
           </Box>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,8 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: "/meigakusai-stamprally2024/",
   plugins: [react()],
-})
+});


### PR DESCRIPTION
## 修正内容
#28
- gh-pagesの追加
- デプロイ用スクリプトの追加
- 画像のsrc属性をパス指定からimportに変更
- vite.configにbaseの追加
- BrowserRouterにbasenameの追加

## デプロイ方法
1. npm run buildを実行
2. npm run deployを実行

## デプロイ先URL
https://nkc-ug.github.io/meigakusai-stamprally2024/